### PR TITLE
daijisen: replace 朮 with 𦬸

### DIFF
--- a/daijisen.go
+++ b/daijisen.go
@@ -1246,7 +1246,7 @@ func (*daijisenExtractor) getFontWide() map[int]string {
 		0xbc70: "异",
 		0xbc72: "麀",
 		0xbc73: "𥫱",
-		0xbc74: "朮",
+		0xbc74: "𦬸",
 		0xbc75: "𧐐",
 		0xbd5c: "慒",
 		0xbd5d: "𪙉",


### PR DESCRIPTION
𦬸 is the character in the epwing. I must have gotten lazy when I originally updated daijisen